### PR TITLE
1.14.2 InventoryClickEvent

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -79,9 +79,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>github.scarsz.discordsrv</groupId>
-            <artifactId>DiscordSRV</artifactId>
-            <version>1.16.5</version>
+            <groupId>com.discordsrv</groupId>
+            <artifactId>discordsrv</artifactId>
+            <version>1.16.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/plugin/src/main/java/io/github/radbuilder/emojichat/EmojiChatListener.java
+++ b/plugin/src/main/java/io/github/radbuilder/emojichat/EmojiChatListener.java
@@ -156,12 +156,12 @@ class EmojiChatListener implements Listener {
 	
 	@EventHandler
 	void onInventoryClick(InventoryClickEvent event) {
-		if (event.getInventory().getTitle().contains("Emoji List")) {
+		if (event.getView().getTitle().contains("Emoji List")) {
 			event.setCancelled(true);
 			if (event.getCurrentItem() != null && event.getCurrentItem().getType() == Material.DIAMOND && event.getCurrentItem().hasItemMeta()
 					&& event.getCurrentItem().getItemMeta().hasDisplayName()) { // Make sure the item clicked is a page change item
 				try {
-					int currentPage = Integer.parseInt(event.getInventory().getTitle().split(" ")[3]) - 1; // Get the page number from the title
+					int currentPage = Integer.parseInt(event.getView().getTitle().split(" ")[3]) - 1; // Get the page number from the title
 					
 					if (event.getCurrentItem().getItemMeta().getDisplayName().contains("<-")) { // Back button
 						event.getWhoClicked().openInventory(plugin.emojiChatGui.getInventory(currentPage - 1));

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <!--</repository>-->
         <!-- DiscordSRV Backup Repo -->
         <repository>
-            <id>repo-androkai</id>
-            <url>https://repo.androkai.net/minecraft</url>
+            <id>Scarsz-Nexus</id>
+            <url>https://nexus.scarsz.me/content/groups/public/</url>
         </repository>
         <!-- MVdWPlaceholderAPI -->
         <repository>


### PR DESCRIPTION
> Could not pass event InventoryClickEvent to EmojiChat v1.8.1
22.06 13:42:00 [Server] INFO java.lang.NoSuchMethodError: org.bukkit.inventory.Inventory.getTitle()

Inventory.getTitle() is Deprecated in 1.14.2
It is required to obtain inventory title via inventory instance

DiscordSRV repository link is changed for original repository was unavailable at the moment of compiling

Also you may want to change spigot api version, i've encountered some problems with org.json with spigot 1.14 although it's working on server 1.14 after compiling with spigot api 1.13