### PR TITLE
Fixed command conflict with other plugin

### DIFF
--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -18,6 +18,9 @@ metrics-collection: 'FULL'
 # If you're using chat color plugins, this will remove the coloring for emojis to be displayed correctly.
 fix-emoji-coloring: false
 
+# Aliases for emoji command
+command-aliases: ['ec', 'echat']
+
 # If emojis should be displayed on signs (shortcuts and full names supported).
 emojis-on-signs: false
 

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -7,12 +7,6 @@ main: io.github.radbuilder.emojichat.EmojiChat
 
 softdepend: [DiscordSRV, DiscordSRV-Staff-Chat, MVdWPlaceholderAPI, PlaceholderAPI, TelegramChat]
 
-commands:
-  emojichat:
-    description: The main EmojiChat command
-    aliases: ec
-    usage: /<command>
-
 permissions:
   emojichat.*:
     description: Allows you to use all of the EmojiChat commands and features


### PR DESCRIPTION
The alias `/ec` was conflicted with EssentialsX and other plugin commands. EssentialsX is a must-have plugin and might cause users to avoid using EmojiChat because of that.

I already fixed and tested, it's working as intended, the user can now add aliases for command they want to use for EmojiChat (maybe consider this a new feature 😆)

![image](https://user-images.githubusercontent.com/15262229/97868852-017e4980-1d43-11eb-9d53-4cf4bf5e5460.png)

![image](https://user-images.githubusercontent.com/15262229/97868879-0e9b3880-1d43-11eb-8609-238c6b476a53.png)

